### PR TITLE
Improve re-roll UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
         </div>
 
         <button id="roll-button" class="control-button">Roll Dice!</button>
+        <button id="keep-button" class="control-button hidden">Keep Results</button>
 
         <div class="message-area" id="message-area">
             Welcome, Survivor! Roll the dice to fight the horde.

--- a/styles.css
+++ b/styles.css
@@ -112,6 +112,10 @@ body {
     cursor: not-allowed;
 }
 
+.hidden {
+    display: none;
+}
+
 .message-area {
     margin-top: 1.5rem;
     min-height: 70px; /* Increased height for more messages */

--- a/ui.js
+++ b/ui.js
@@ -11,6 +11,7 @@ const dieElements = [
     document.getElementById('die3')
 ];
 const rollButton = document.getElementById('roll-button');
+const keepButton = document.getElementById('keep-button');
 const messageArea = document.getElementById('message-area');
 const zombieArtArea = document.getElementById('zombie-art-area');
 const gameOverModal = document.getElementById('game-over-modal');
@@ -35,6 +36,7 @@ function initGame() {
     messageArea.textContent = "The night begins... Roll the dice to survive!";
     rollButton.textContent = "Roll Dice!";
     rollButton.disabled = false;
+    keepButton.classList.add('hidden');
     gameOverModal.classList.remove('active');
     
     dieElements.forEach((die, index) => {
@@ -111,6 +113,7 @@ function handleRollDice() {
         gameState.rerollsAvailable = 0; // Consume the re-roll
         updateDisplay(); // Update re-roll count display
         disableDieSelection(); // Make dice no longer selectable
+        keepButton.classList.add('hidden');
         rollButton.textContent = "Rolling..."; // Indicate action
 
         // Count selected dice using our stored selection state
@@ -199,8 +202,9 @@ function handleRollDice() {
                             gameState.isRerollPhase = true;
                             rollButton.textContent = "Re-roll Selected";
                             rollButton.disabled = false; // Enable button for re-roll confirmation
+                            keepButton.classList.remove('hidden');
                             enableDieSelection(); // Allow player to click dice
-                            currentMessages.push("Initial roll complete. Select dice to re-roll, then click 'Re-roll Selected'.");
+                            currentMessages.push("Initial roll complete. Select dice to re-roll, then click 'Re-roll Selected', or click 'Keep Results' to continue.");
                             messageArea.innerHTML = currentMessages.join('<br>');
                         } else {
                             // No re-rolls available, proceed to resolve effects
@@ -210,7 +214,23 @@ function handleRollDice() {
                 }
             }, 50);
         });
+
     }
+}
+
+/**
+ * Handles keeping the initial roll without using the re-roll.
+ */
+function handleKeepResults() {
+    if (!gameState.isRerollPhase || gameState.gameOver) return;
+
+    disableDieSelection();
+    keepButton.classList.add('hidden');
+    rollButton.disabled = true;
+    rollButton.textContent = "Resolving...";
+
+    const messages = ["Keeping current results."];
+    resolveDiceEffects(messages);
 }
 
 /**
@@ -242,6 +262,7 @@ function updateDisplay() {
 
 // --- Event Listeners ---
 rollButton.addEventListener('click', handleRollDice);
+keepButton.addEventListener('click', handleKeepResults);
 playAgainButton.addEventListener('click', initGame);
 
 // --- Initial Game Setup ---


### PR DESCRIPTION
## Summary
- present a `Keep Results` button after the initial roll
- style button with a new `.hidden` CSS class
- allow players to keep results without a re-roll

## Testing
- `npm test` *(fails: Could not find package.json)*