### PR TITLE
Expands game to infinite stages with increasing difficulty

### DIFF
--- a/game.js
+++ b/game.js
@@ -4,6 +4,7 @@ const MAX_BARRICADE_STRENGTH = 30; // Max barricade can be repaired to
 const INITIAL_ZOMBIES = 10;
 const MAX_ROUNDS = 10;
 const NUM_DICE = 3;
+const STAGE_ZOMBIE_INCREMENT = 5;
 const OVERWHELMED_THRESHOLD = 15; // Zombies count above which they do bonus damage
 const OVERWHELMED_BONUS_DAMAGE = 5; // Bonus damage when overwhelmed
 
@@ -26,6 +27,8 @@ let gameState = {
     barricadeStrength: INITIAL_BARRICADE_STRENGTH,
     zombies: INITIAL_ZOMBIES,
     round: 1,
+    stage: 1,
+    stageOutcome: null,
     gameOver: false,
     diceValues: [null, null, null], // Stores face objects of current roll
     rerollsAvailable: 1, // Feature 1: Re-rolls per round
@@ -174,6 +177,8 @@ function zombiesAttack(currentMessages) {
 function checkWinLoss() {
     let gameEndStatus = null; // To store the type of game end
 
+    const totalRound = (gameState.stage - 1) * MAX_ROUNDS + gameState.round;
+
     if (gameState.barricadeStrength <= 0) {
         gameEndStatus = "loss_barricade";
     } else if (gameState.zombies <= 0 && gameState.round <= MAX_ROUNDS) { // Win by eliminating all zombies
@@ -185,38 +190,38 @@ function checkWinLoss() {
 
     if (gameEndStatus && !gameState.gameOver) { // Process game end only once
         gameState.gameOver = true;
+        gameState.stageOutcome = gameEndStatus.startsWith('loss') ? 'lost' : 'won';
         rollButton.disabled = true;
         disableDieSelection(); // Ensure dice are not interactive post-game
 
-        // Update highest round reached
-        if (gameState.round > gameState.highestRound) {
-            gameState.highestRound = gameState.round;
+        // Update highest round reached (across stages)
+        if (totalRound > gameState.highestRound) {
+            gameState.highestRound = totalRound;
             localStorage.setItem(HIGHEST_ROUND_KEY, gameState.highestRound.toString());
         }
 
         // Update earliest win if this is a win
         if (gameEndStatus.startsWith('win')) {
-            const currentRound = gameState.round;
-            if (gameState.earliestWin === 0 || currentRound < gameState.earliestWin) {
-                gameState.earliestWin = currentRound;
+            if (gameState.earliestWin === 0 || totalRound < gameState.earliestWin) {
+                gameState.earliestWin = totalRound;
                 localStorage.setItem(EARLIEST_WIN_KEY, gameState.earliestWin.toString());
             }
         }
 
         switch(gameEndStatus) {
             case "loss_barricade":
-                modalTitle.textContent = "Game Over!";
-                modalMessage.textContent = "The zombies have breached the barricade! 💀";
-                messageArea.innerHTML += "<br><b>GAME OVER! The horde broke through!</b>";
+                modalTitle.textContent = "Stage Failed";
+                modalMessage.textContent = "The zombies breached your barricade! Try again.";
+                messageArea.innerHTML += "<br><b>STAGE FAILED! The horde broke through!</b>";
                 break;
             case "win_no_zombies":
-                modalTitle.textContent = "You Won!";
-                modalMessage.textContent = "You've defeated all the zombies! 🎉";
+                modalTitle.textContent = "Stage Cleared";
+                modalMessage.textContent = `Stage ${gameState.stage} cleared! All zombies defeated! 🎉`;
                 messageArea.innerHTML += "<br><b>VICTORY! All zombies eliminated!</b>";
                 break;
             case "win_survived_rounds":
-                 modalTitle.textContent = "You Survived!";
-                 modalMessage.textContent = `You made it through ${MAX_ROUNDS} rounds! The dawn is here! 🌅`;
+                 modalTitle.textContent = "Stage Survived";
+                 modalMessage.textContent = `Stage ${gameState.stage} complete! You lasted ${MAX_ROUNDS} rounds! 🌅`;
                  messageArea.innerHTML += `<br><b>SURVIVED! You lasted ${MAX_ROUNDS} rounds!</b>`;
                  break;
         }

--- a/game.js
+++ b/game.js
@@ -1,12 +1,35 @@
 // Game Configuration
 const INITIAL_BARRICADE_STRENGTH = 20;
 const MAX_BARRICADE_STRENGTH = 30; // Max barricade can be repaired to
-const INITIAL_ZOMBIES = 10;
+const INITIAL_ZOMBIES = 3; // Lower starting difficulty
 const MAX_ROUNDS = 10;
 const NUM_DICE = 3;
-const STAGE_ZOMBIE_INCREMENT = 5;
+// Calculate the additional zombies added when starting a specific stage.
+// The increment slowly grows, following a ramp where the value n is used for
+// n stages before increasing. Example: +1 (1 stage), +2 (2 stages), +3 (3
+// stages), and so on.
+function getStageZombieIncrement(stage) {
+    if (stage <= 1) return 0;
+    let increment = 1;
+    let stagesRemaining = stage - 1;
+    while (stagesRemaining > increment) {
+        stagesRemaining -= increment;
+        increment++;
+    }
+    return increment;
+}
 const OVERWHELMED_THRESHOLD = 15; // Zombies count above which they do bonus damage
 const OVERWHELMED_BONUS_DAMAGE = 5; // Bonus damage when overwhelmed
+
+// Calculate the number of zombies that start a given stage using the ramp
+// increment formula defined in getStageZombieIncrement().
+function getInitialZombiesForStage(stage) {
+    let zombies = INITIAL_ZOMBIES;
+    for (let i = 2; i <= stage; i++) {
+        zombies += getStageZombieIncrement(i);
+    }
+    return zombies;
+}
 
 // High Score Storage Keys
 const HIGHEST_ROUND_KEY = 'dicevzombz_highest_round';

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
         <div class="stats-bar">
             <span id="stage-display">Stage: 1</span>
             <span id="round-display">Round: 1/10</span>
-            <span id="zombies-display">Zombies: 10</span>
+            <span id="zombies-display">Zombies: 3</span>
             <span id="barricade-display">Barricade: 20</span>
             <span id="reroll-display">Re-rolls: 1</span>
             <span id="highest-round-display">Furthest: 0</span>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <h1 class="game-title">Dice vs Zombies</h1>
 
         <div class="stats-bar">
+            <span id="stage-display">Stage: 1</span>
             <span id="round-display">Round: 1/10</span>
             <span id="zombies-display">Zombies: 10</span>
             <span id="barricade-display">Barricade: 20</span>

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,5 @@
 // DOM Elements
+const stageDisplay = document.getElementById('stage-display');
 const roundDisplay = document.getElementById('round-display');
 const zombiesDisplay = document.getElementById('zombies-display');
 const barricadeDisplay = document.getElementById('barricade-display');
@@ -22,26 +23,34 @@ const playAgainButton = document.getElementById('play-again-button');
  * Initializes or resets the game to its starting state.
  */
 function initGame() {
+    gameState.stage = 1;
+    startStage();
+}
+
+function startStage() {
     gameState.barricadeStrength = INITIAL_BARRICADE_STRENGTH;
-    gameState.zombies = INITIAL_ZOMBIES;
+    gameState.zombies = INITIAL_ZOMBIES + STAGE_ZOMBIE_INCREMENT * (gameState.stage - 1);
     gameState.round = 1;
     gameState.gameOver = false;
     gameState.diceValues = [null, null, null];
     gameState.rerollsAvailable = 1;
     gameState.isRerollPhase = false;
     gameState.diceSelectedForReroll = [false, false, false];
-    
+    gameState.stageOutcome = null;
+
     updateDisplay();
-    messageArea.textContent = "The night begins... Roll the dice to survive!";
+    const startMsg = gameState.stage === 1
+        ? "The night begins... Roll the dice to survive!"
+        : `Stage ${gameState.stage} begins... Roll the dice to survive!`;
+    messageArea.textContent = startMsg;
     rollButton.textContent = "Roll Dice!";
     rollButton.disabled = false;
     gameOverModal.classList.remove('active');
-    
+
     dieElements.forEach((die, index) => {
         die.textContent = '🎲';
-        die.className = 'die'; // Reset classes
-        // Remove any existing click listeners for safety. They are added in enableDieSelection.
-        die.removeEventListener('click', onDieSelectClickHandler); 
+        die.className = 'die';
+        die.removeEventListener('click', onDieSelectClickHandler);
     });
 }
 
@@ -217,6 +226,7 @@ function handleRollDice() {
  * Updates all display elements on the page with current game state.
  */
 function updateDisplay() {
+    stageDisplay.textContent = `Stage: ${gameState.stage}`;
     roundDisplay.textContent = `Round: ${gameState.round}/${MAX_ROUNDS}`;
     zombiesDisplay.textContent = `Zombies: ${gameState.zombies}`;
     barricadeDisplay.textContent = `Barricade: ${gameState.barricadeStrength}`;
@@ -240,9 +250,16 @@ function updateDisplay() {
     }
 }
 
+function handlePlayAgain() {
+    if (gameState.stageOutcome === 'won') {
+        gameState.stage++;
+    }
+    startStage();
+}
+
 // --- Event Listeners ---
 rollButton.addEventListener('click', handleRollDice);
-playAgainButton.addEventListener('click', initGame);
+playAgainButton.addEventListener('click', handlePlayAgain);
 
 // --- Initial Game Setup ---
 window.onload = function() {

--- a/ui.js
+++ b/ui.js
@@ -29,7 +29,7 @@ function initGame() {
 
 function startStage() {
     gameState.barricadeStrength = INITIAL_BARRICADE_STRENGTH;
-    gameState.zombies = INITIAL_ZOMBIES + STAGE_ZOMBIE_INCREMENT * (gameState.stage - 1);
+    gameState.zombies = getInitialZombiesForStage(gameState.stage);
     gameState.round = 1;
     gameState.gameOver = false;
     gameState.diceValues = [null, null, null];


### PR DESCRIPTION
Game now progresses through increasingly difficult 10-round stages.

Initial balance:
- Stage 1 starts with 3 zombies.
- Each stage adds more zombies, with the amount added slowly increasing as well. Formula is each increase in starting zombies is applied to the number of stages equal to the increase. In other words, the first increase is +1 zombie, so stage 2 has 4 zombies. The next increase is +2 zombies, which is cumulatively applied to stages 3 and 4. The next increase is +3 zombies, cumulatively added to stages 5, 6, and 7. Then +4 zombies for stages 8, 9, 10, and 11, and so on.